### PR TITLE
Patch: catch up recent DokuWiki development

### DIFF
--- a/action.php
+++ b/action.php
@@ -38,25 +38,25 @@ class action_plugin_custombuttons extends DokuWiki_Action_Plugin {
         foreach ($conf as $button) {
             $ico = '../../plugins/custombuttons/';
             if (!$button['icon']) {
-                $ico .= 'genpng.php?text=' . $button["label"];
+                $ico .= 'genpng.php?text='. $button['label'];
             } else {
-                $ico .= 'ico/' . $button['icon'];
+                $ico .= 'ico/'. $button['icon'];
             }
 
-            if ($button["type"] == 1) {
+            if ($button['type'] == 1) {
                 $buttonlist[] = array(
                     'type' => 'format',
-                    'title' => $button["label"],
+                    'title' => $button['label'],
                     'icon' => $ico,
-                    'open' => $button["pretag"],
-                    'close' => $button["posttag"]
+                    'open' => $button['pretag'],
+                    'close' => $button['posttag']
                 );
             } else {
                 $buttonlist[] = array(
                     'type' => 'insert',
-                    'title' => $button["label"],
+                    'title' => $button['label'],
                     'icon' => $ico,
-                    'insert' => $button["code"],
+                    'insert' => $button['code'],
                     'block' => true
                 );
             }

--- a/action.php
+++ b/action.php
@@ -5,20 +5,13 @@
  * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
  * @author  Constantinos Xanthopoulos <conx@xanthopoulos.info>
  */
-
-// must be run within Dokuwiki
-if (!defined('DOKU_INC')) die();
-
-/**
- * Add Event handler
- */
 class action_plugin_custombuttons extends DokuWiki_Action_Plugin {
 
     /**
      * Registers a callback function for a given event
      */
-    function register(Doku_Event_Handler $controller) {
-        if($this->loadCBData())
+    public function register(Doku_Event_Handler $controller) {
+        if ($this->loadCBData())
             $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insert_button', array());
     }
 
@@ -28,10 +21,9 @@ class action_plugin_custombuttons extends DokuWiki_Action_Plugin {
      * @return bool|mixed
      */
     protected function loadCBData() {
-        $json = new JSON(JSON_LOOSE_TYPE);
         $file = @file_get_contents(DOKU_PLUGIN . "custombuttons/config.json");
         if(!$file) return false;
-        return $json->decode($file);
+        return json_decode($file, true);
     }
 
     /**
@@ -43,15 +35,15 @@ class action_plugin_custombuttons extends DokuWiki_Action_Plugin {
         $conf = $this->loadCBData();
 
         $buttonlist = array();
-        foreach($conf as $button) {
+        foreach ($conf as $button) {
             $ico = '../../plugins/custombuttons/';
-            if(!$button['icon']) {
+            if (!$button['icon']) {
                 $ico .= 'genpng.php?text=' . $button["label"];
             } else {
                 $ico .= 'ico/' . $button['icon'];
             }
 
-            if($button["type"] == 1) {
+            if ($button["type"] == 1) {
                 $buttonlist[] = array(
                     'type' => 'format',
                     'title' => $button["label"],
@@ -81,7 +73,7 @@ class action_plugin_custombuttons extends DokuWiki_Action_Plugin {
     public function insert_button(Doku_Event $event, $param) {
         $buttonlist = $this->makelist();
 
-        if($this->getConf('usepicker')) {
+        if ($this->getConf('usepicker')) {
             $event->data[] = array(
                 'type' => 'picker',
                 'title' => $this->getLang('picker'),

--- a/admin.php
+++ b/admin.php
@@ -56,34 +56,35 @@ class admin_plugin_custombuttons extends DokuWiki_Admin_Plugin {
      * Execute the requested action
      */
     public function handle() {
+        global $INPUT;
 
-        if (isset($_REQUEST['add'])) {
+        if ($INPUT->has('add')) {
             if (!checkSecurityToken()) return;
 
             $conf = $this->loadCBData();
-            if(!$conf) {
+            if (!$conf) {
                 $conf = array();
             }
             $type = 0;
-            if ($_REQUEST["pretag"] != "" && $_REQUEST["posttag"] != "") {
+            if ($INPUT->str('pretag') != '' && $INPUT->str('posttag') != '') {
                 $type = 1;
             }
             array_push($conf, array(
-                'label' => $_REQUEST["label"],
-                'code'  => $_REQUEST["code"],
+                'label' => $INPUT->str('label'),
+                'code'  => $INPUT->str('code'),
                 'type'  => $type,
-                'pretag'  => $_REQUEST["pretag"],
-                'posttag' => $_REQUEST["posttag"],
-                'icon' => $_REQUEST["icon"],
+                'pretag'  => $INPUT->str('pretag'),
+                'posttag' => $INPUT->str('posttag'),
+                'icon'  => $INPUT->str('icon'),
             ));
 
             $this->saveCBData($conf);
             $this->reloadBar();
-        } elseif (isset($_REQUEST['delete'])) {
+        } elseif ($INPUT->has('delete')) {
             if (!checkSecurityToken()) return;
 
             $conf = $this->loadCBData();
-            unset($conf[$_REQUEST["delete"]]);
+            unset($conf[$INPUT->int('delete')]);
             $this->saveCBData($conf);
             $this->reloadBar();
         }

--- a/admin.php
+++ b/admin.php
@@ -7,187 +7,181 @@
  */
 class admin_plugin_custombuttons extends DokuWiki_Admin_Plugin {
 
-	/**
-	 * Return true for access only by admins (config:superuser) or false if managers are allowed as well
-	 *
-	 * @return bool
-	 */
-	public function forAdminOnly() {
-		return true;
-	}
+    /**
+     * Return true for access only by admins (config:superuser) or false if managers are allowed as well
+     *
+     * @return bool
+     */
+    public function forAdminOnly() {
+        return true;
+    }
 
-	/**
-	 * return prompt for admin menu
-	 */
-	function getMenuText($language) {
-		return $this->getLang('name');
-	}
+    /**
+     * return prompt for admin menu
+     */
+    public function getMenuText($language) {
+        return $this->getLang('name');
+    }
 
-	/**
-	 * Read config
-	 *
-	 * @return bool|mixed
-	 */
-	protected function loadCBData() {
-		$file = @file_get_contents(DOKU_PLUGIN."custombuttons/config.json");
-		if(!$file) return false;
-		return json_decode($file, true);
-	}
+    /**
+     * Read config
+     *
+     * @return bool|mixed
+     */
+    protected function loadCBData() {
+        $file = @file_get_contents(DOKU_PLUGIN.'custombuttons/config.json');
+        if (!$file) return false;
+        return json_decode($file, true);
+    }
 
-	/**
-	 * Store config
-	 *
-	 * @param $conf
-	 */
-	protected function saveCBData($conf) {
-		$configfile = DOKU_PLUGIN."custombuttons/config.json";
-		if(is_writable($configfile) || (!file_exists($configfile) && is_writable(DOKU_PLUGIN."custombuttons"))) {
-			file_put_contents($configfile, json_encode($conf));
-		} else {
-			msg($this->getLang('txt_error'), -1);
-		}
-	}
+    /**
+     * Store config
+     *
+     * @param $conf
+     */
+    protected function saveCBData($conf) {
+        $configfile = DOKU_PLUGIN.'custombuttons/config.json';
+        if (is_writable($configfile) || (!file_exists($configfile) && is_writable(DOKU_PLUGIN.'custombuttons'))) {
+            file_put_contents($configfile, json_encode($conf));
+        } else {
+            msg($this->getLang('txt_error'), -1);
+        }
+    }
 
-	protected function reloadBar() {
-		touch(DOKU_CONF."local.php");
-	}
+    protected function reloadBar() {
+        touch(DOKU_CONF.'local.php');
+    }
 
-	public function handle() {
+    /**
+     * Execute the requested action
+     */
+    public function handle() {
 
-		if (isset($_REQUEST['add'])) {
-			if (!checkSecurityToken()) return;
+        if (isset($_REQUEST['add'])) {
+            if (!checkSecurityToken()) return;
 
-			$conf = $this->loadCBData();
-			if(!$conf) {
-				$conf = array();
-			}
-			$type = 0;
-			if ($_REQUEST["pretag"] != "" && $_REQUEST["posttag"] != "") {
-				$type = 1;
-			}
-			array_push($conf, array(
-				"label"	 => $_REQUEST["label"],
-				"code"	  => $_REQUEST["code"],
-				"type"	  => $type,
-				"pretag"	=> $_REQUEST["pretag"],
-				"posttag"   => $_REQUEST["posttag"],
-				"icon"	  => $_REQUEST["icon"],
-			));
+            $conf = $this->loadCBData();
+            if(!$conf) {
+                $conf = array();
+            }
+            $type = 0;
+            if ($_REQUEST["pretag"] != "" && $_REQUEST["posttag"] != "") {
+                $type = 1;
+            }
+            array_push($conf, array(
+                'label' => $_REQUEST["label"],
+                'code'  => $_REQUEST["code"],
+                'type'  => $type,
+                'pretag'  => $_REQUEST["pretag"],
+                'posttag' => $_REQUEST["posttag"],
+                'icon' => $_REQUEST["icon"],
+            ));
 
-			$this->saveCBData($conf);
-			$this->reloadBar();
-		} elseif (isset($_REQUEST['delete'])) {
-			if (!checkSecurityToken()) return;
+            $this->saveCBData($conf);
+            $this->reloadBar();
+        } elseif (isset($_REQUEST['delete'])) {
+            if (!checkSecurityToken()) return;
 
-			$conf = $this->loadCBData();
-			unset($conf[$_REQUEST["delete"]]);
-			$this->saveCBData($conf);
-			$this->reloadBar();
-		}
-	}
+            $conf = $this->loadCBData();
+            unset($conf[$_REQUEST["delete"]]);
+            $this->saveCBData($conf);
+            $this->reloadBar();
+        }
+    }
 
-	public function html() {
-		global $ID;
-		$conf = $this->loadCBData();
+    /**
+     * Render HTML output
+     */
+    public function html() {
+        global $ID;
+        $conf = $this->loadCBData();
 
-		echo '
-<div id = "custombuttons">
-	<h1>'.$this->getLang ( 'name' ).'</h1>
+        echo '<div id="custombuttons">';
+        echo '<h1>'.$this->getLang('name').'</h1>';
 
-	<h3>'.$this->getLang ( 'btnslist' ).'</h3>
-	<form id = "cb_button_list" action = "'.wl ( $ID ).'" method = "post">
-		<input type = "hidden" name = "do" value = "admin" />
-		<input type = "hidden" name = "page" value = "'.$this->getPluginName ( ).'" />';
-		formSecurityToken ( );
-		echo '
-		<table class = "inline">
-			<tr>
-				<th>'.$this->getLang ( 'btnslist_label' ).'</th>
-				<th>'.$this->getLang ( 'btnslist_code' ).'</th>
-				<th>'.$this->getLang ( 'btnslist_delete' ).'</th>
-			</tr>';
-		if ( $conf ) {
-			foreach ( $conf as $key => $button ) {
-				echo '
-			<tr>';
-				if ( !$button["type"] ) {
-					echo '
-				<td>'.hsc ( $button["label"] ).'</td>
-				<td>'.hsc ( $button["code"] ).'</td>';
-				} else {
-					$icon = '';
-					if ( $button['icon'] ) $icon = '<img src="' . DOKU_BASE.'lib/plugins/custombuttons/ico/'.$button['icon']. '" /> ';
-					echo '
-				<td>'.$icon.hsc ( $button["label"] ).'</td>
-				<td>'.hsc ( $button["pretag"] ).hsc ( $button["code"] ).hsc ( $button["posttag"] ).'</td>';
-				};
-				echo '
-				<td><input type = "radio" name = "delete" value = "'.$key.'"/></td>
-			</tr>';
-			}
-		}
-		echo '
-		</table>
-		<input type = "submit" class = "button" value = "'.$this->getLang ( 'btn_delete' ).'"/>
-	</form>
-     </br></br>
-	
-	<h3>'.$this->getLang('addbtn').'</h3>
-	<form id = "cb_add_button" action = "'.wl ( $ID ).'" method = "post">
-		<input type = "hidden" name = "do" value = "admin" />
-		<input type = "hidden" name = "add" value = "1" />
-		<input type = "hidden" name = "page" value = "'.$this->getPluginName ( ).'" />';
-		formSecurityToken ( );
-		echo '
-		<table>
-			<tr>
-				<th>'.$this->getLang ( 'addbtn_icon' ).'</th>
-				<td>
-					<select name = "icon">
-						<option value = "">'.$this->getLang ( 'addbtn_textonly' ).'</option>';
-		$files = glob ( dirname ( __FILE__ ).'/ico/*.png' );
-		foreach ( $files as $file ) {
-			$file = hsc ( basename ( $file ) );
-			echo '
-						<option value = "'.$file.'">'.$file.'</option>';
-		};
-		echo '
-					</select>
-				</td>
-				<td></td>
-			</tr>
-			<tr>
-				<th>'.$this->getLang ( 'addbtn_label' ).'</th>
-				<td>
-					<input type = "text" name = "label" />
-				</td>
-				<td></td>
-			</tr>
-			<tr>
-				<th>'.$this->getLang ( 'addbtn_pretag' ).'</th>
-				<td>
-					<input type = "text" name = "pretag" />
-				</td>
-				<td>*</td>
-			</tr>
-			<tr>
-				<th>'.$this->getLang ( 'addbtn_posttag' ).'</th>
-				<td>
-					<input type="text" name = "posttag" />
-				</td>
-				<td>*</td>
-			</tr>
-			<tr>
-				<th>'.$this->getLang ( 'addbtn_code' ).'</th>
-				<td>
-					<input type = "text" name = "code" />
-				</td>
-				<td></td>
-			</tr>
-		</table>
-		<input type = "submit" class = "button" value = "'.$this->getLang ( 'btn_add' ).'" />
-	</form>
-	<div id = "cb_comment" >'.$this->getLang ( 'txt_comment' ).'</div>
-</div>';
-	}
+        // list of custom buttons
+        echo '<h3>'.$this->getLang('btnslist').'</h3>';
+        echo '<form id="cb_button_list" action="'.wl($ID).'" method="post">'
+            .'<input type="hidden" name="do" value="admin" />'
+            .'<input type="hidden" name="page" value="'.$this->getPluginName().'" />';
+
+        formSecurityToken();
+
+        echo '<table class = "inline">';
+        echo '<tr>'
+            .'<th>'.$this->getLang('btnslist_label').'</th>'
+            .'<th>'.$this->getLang('btnslist_code').'</th>'
+            .'<th>'.$this->getLang('btnslist_delete').'</th>'
+            .'</tr>';
+        if ($conf) {
+            foreach ($conf as $key => $button) {
+                echo '<tr>';
+                if (!$button['type']) {
+                    echo '<td>'.hsc($button['label']).'</td>'
+                        .'<td>'.hsc($button['code']).'</td>';
+                } else {
+                    $icon = '';
+                    if ($button['icon']) {
+                        $icon = '<img src="'. DOKU_BASE.'lib/plugins/custombuttons/ico/'.$button['icon'].'" /> ';
+                    }
+                    echo '<td>'.$icon.hsc($button['label']).'</td>'
+                        .'<td>'.hsc($button['pretag']).hsc($button['code']).hsc($button['posttag']).'</td>';
+                };
+                echo '<td><input type="checkbox" name="delete" value="'.$key.'"/></td>';
+                echo '</tr>';
+            }
+        }
+        echo '</table>';
+        echo '<input type="submit" class="button" value="'.$this->getLang('btn_delete').'"/>';
+        echo '</form>';
+        echo '</br></br>';
+
+        // add custom button form
+        echo '<h3>'.$this->getLang('addbtn').'</h3>';
+        echo '<form id="cb_add_button" action="'.wl($ID).'" method="post">'
+            .'<input type="hidden" name="do" value="admin" />'
+            .'<input type="hidden" name="add" value="1" />'
+            .'<input type="hidden" name="page" value="'.$this->getPluginName().'" />';
+        formSecurityToken();
+        echo '<table>';
+        echo '<tr>';
+        echo '<th>'.$this->getLang('addbtn_icon').'</th>';
+        echo '<td>'
+            .'<select name="icon">'
+            .'<option value="">'.$this->getLang('addbtn_textonly').'</option>';
+        $files = glob(dirname(__FILE__).'/ico/*.png');
+        foreach ($files as $file) {
+            $file = hsc(basename($file));
+            echo '<option value="'.$file.'">'.$file.'</option>';
+        };
+        echo '</select>';
+        echo '</td>';
+        echo '<td></td>';
+        echo '</tr>';
+        echo '<tr>'
+            .'<th>'.$this->getLang('addbtn_label').'</th>'
+            .'<td><input type="text" name="label" /></td>'
+            .'<td></td>'
+            .'</tr>';
+        echo '<tr>'
+            .'<th>'.$this->getLang('addbtn_pretag').'</th>'
+            .'<td><input type="text" name="pretag" /></td>'
+            .'<td>*</td>'
+            .'</tr>';
+        echo '<tr>'
+            .'<th>'.$this->getLang('addbtn_posttag').'</th>'
+            .'<td><input type="text" name="posttag" /></td>'
+            .'<td>*</td>'
+            .'</tr>';
+        echo '<tr>'
+            .'<th>'.$this->getLang('addbtn_code').'</th>'
+            .'<td><input type="text" name="code" /></td>'
+            .'<td></td>'
+            .'</tr>';
+        echo '</table>';
+        echo '<input type="submit" class="button" value="'.$this->getLang('btn_add').'" />';
+        echo '</form>';
+        echo '<div id="cb_comment">'.$this->getLang('txt_comment').'</div>';
+        echo '</div>';
+    }
 }

--- a/admin.php
+++ b/admin.php
@@ -5,13 +5,6 @@
  * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
  * @author Constantinos Xanthopoulos <conx@xanthopoulos.info>
  */
-
-// must be run within Dokuwiki
-if (!defined('DOKU_INC')) die();
-
-/**
- * Class admin_plugin_custombuttons
- */
 class admin_plugin_custombuttons extends DokuWiki_Admin_Plugin {
 
 	/**
@@ -36,10 +29,9 @@ class admin_plugin_custombuttons extends DokuWiki_Admin_Plugin {
 	 * @return bool|mixed
 	 */
 	protected function loadCBData() {
-		$json = new JSON(JSON_LOOSE_TYPE);
 		$file = @file_get_contents(DOKU_PLUGIN."custombuttons/config.json");
 		if(!$file) return false;
-		return $json->decode($file);
+		return json_decode($file, true);
 	}
 
 	/**
@@ -48,11 +40,9 @@ class admin_plugin_custombuttons extends DokuWiki_Admin_Plugin {
 	 * @param $conf
 	 */
 	protected function saveCBData($conf) {
-		$json = new JSON();
-		$json = $json->encode($conf);
 		$configfile = DOKU_PLUGIN."custombuttons/config.json";
 		if(is_writable($configfile) || (!file_exists($configfile) && is_writable(DOKU_PLUGIN."custombuttons"))) {
-			file_put_contents($configfile, $json);
+			file_put_contents($configfile, json_encode($conf));
 		} else {
 			msg($this->getLang('txt_error'), -1);
 		}

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -2,6 +2,6 @@ base   custombuttons
 author Constantinos Xanthopoulos, Gerrit Uitslag
 email  conx@xanthopoulos.info, klapinklapin@gmail.com
 date   2019-07-11
-name   Custombuttons Plugin
+name   CustomButtons Plugin
 desc   A plugin for adding custom buttons to the toolbar, to shortcut commonly used code blocks.
 url    https://www.dokuwiki.org/plugin:custombuttons


### PR DESCRIPTION
FIx deprecated DokuWiki **JSON** class method. close #22 
use **$INPUT** instead of raw $_REQUEST for safer access in `admin_plugin_custombuttons::handle()`
coding style 4 spaces for indent, not tab